### PR TITLE
fix: Departure and ArrivalSearch range field must be named range

### DIFF
--- a/traveltimepy/dto/requests/time_filter.py
+++ b/traveltimepy/dto/requests/time_filter.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from typing import List, Optional, Union
 
+from pydantic import Field
 from pydantic.main import BaseModel
 
-from traveltimepy.dto.common import Location, FullRange, Property
+from traveltimepy.dto.common import FullRange, Location, Property
 from traveltimepy.dto.requests.request import TravelTimeRequest
 from traveltimepy.dto.responses.time_filter import TimeFilterResponse
-from traveltimepy.itertools import split, flatten
-from traveltimepy.dto.transportation import PublicTransport, Driving, Ferry, Walking, Cycling, DrivingTrain
+from traveltimepy.dto.transportation import Cycling, Driving, DrivingTrain, Ferry, PublicTransport, Walking
+from traveltimepy.itertools import flatten, split
 
 
 class ArrivalSearch(BaseModel):
@@ -18,7 +19,7 @@ class ArrivalSearch(BaseModel):
     travel_time: int
     transportation: Union[PublicTransport, Driving, Ferry, Walking, Cycling, DrivingTrain]
     properties: List[Property]
-    full_range: Optional[FullRange] = None
+    range: Optional[FullRange] = Field(None, alias="full_range")
 
 
 class DepartureSearch(BaseModel):
@@ -29,7 +30,7 @@ class DepartureSearch(BaseModel):
     travel_time: int
     transportation: Union[PublicTransport, Driving, Ferry, Walking, Cycling, DrivingTrain]
     properties: List[Property]
-    full_range: Optional[FullRange] = None
+    range: Optional[FullRange] = Field(None, alias="full_range")
 
 
 class TimeFilterRequest(TravelTimeRequest[TimeFilterResponse]):


### PR DESCRIPTION
- the API expects 'range' as keyword, not 'full_range'

Renamed field to "range" but kept "full_range" as alias to ensure backwards-compatibility