### PR TITLE
Add throttling

### DIFF
--- a/traveltimepy/dto/requests/request.py
+++ b/traveltimepy/dto/requests/request.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, TypeVar, Generic
+from typing import Generic, List, TypeVar
 
 from pydantic import BaseModel
 
@@ -16,3 +16,8 @@ class TravelTimeRequest(ABC, BaseModel, Generic[T]):
     @abstractmethod
     def merge(self, responses: List[T]) -> T:
         pass
+
+    @property
+    def api_hits_count(self) -> int:
+        """Return the number of hits the API will count when sending this request."""
+        return 1  # default value to avoid breaking existing code

--- a/traveltimepy/dto/requests/time_filter.py
+++ b/traveltimepy/dto/requests/time_filter.py
@@ -46,5 +46,6 @@ class TimeFilterRequest(TravelTimeRequest[TimeFilterResponse]):
     def merge(self, responses: List[TimeFilterResponse]) -> TimeFilterResponse:
         return TimeFilterResponse(results=flatten([response.results for response in responses]))
 
+    @property
     def api_hits_count(self) -> int:
         return len(self.departure_searches) + len(self.arrival_searches)

--- a/traveltimepy/dto/requests/time_filter.py
+++ b/traveltimepy/dto/requests/time_filter.py
@@ -3,11 +3,11 @@ from typing import List, Optional, Union
 
 from pydantic.main import BaseModel
 
-from traveltimepy.dto.common import Location, FullRange, Property
+from traveltimepy.dto.common import FullRange, Location, Property
 from traveltimepy.dto.requests.request import TravelTimeRequest
 from traveltimepy.dto.responses.time_filter import TimeFilterResponse
-from traveltimepy.itertools import split, flatten
-from traveltimepy.dto.transportation import PublicTransport, Driving, Ferry, Walking, Cycling, DrivingTrain
+from traveltimepy.dto.transportation import Cycling, Driving, DrivingTrain, Ferry, PublicTransport, Walking
+from traveltimepy.itertools import flatten, split
 
 
 class ArrivalSearch(BaseModel):
@@ -45,3 +45,6 @@ class TimeFilterRequest(TravelTimeRequest[TimeFilterResponse]):
 
     def merge(self, responses: List[TimeFilterResponse]) -> TimeFilterResponse:
         return TimeFilterResponse(results=flatten([response.results for response in responses]))
+
+    def api_hits_count(self) -> int:
+        return len(self.departure_searches) + len(self.arrival_searches)

--- a/traveltimepy/http.py
+++ b/traveltimepy/http.py
@@ -10,7 +10,6 @@ from traveltimepy.dto.requests.request import TravelTimeRequest
 from traveltimepy.dto.responses.error import ResponseError
 from traveltimepy.errors import ApiError
 from traveltimepy.utils.throttler import Throttler
-from traveltimepy.utils.utils import count_api_hits
 
 T = TypeVar('T')
 R = TypeVar('R')
@@ -35,7 +34,6 @@ async def _execute_post_request_async(
     # Construct the URL for the API endpoint
     url = f"https://api.traveltimeapp.com/v4/{path}"
     # Send a POST request to the API with the given headers and data
-    print(request.json())
     try:
         async with client.post(url=url, headers=headers, data=request.json()) as resp:
             # Process the response and return it as an instance of the given response class
@@ -59,7 +57,7 @@ async def send_post_request_async(
         return await _execute_post_request_async(client, response_class, path, headers, request)
     else:
         # Otherwise, use the throttler to enforce the request rate limit before sending the POST request
-        async with throttler.use(count_api_hits(request)):
+        async with throttler.use(num_requests=request.api_hits_count):
             return await _execute_post_request_async(
                 client, response_class, path, headers, request
             )

--- a/traveltimepy/http.py
+++ b/traveltimepy/http.py
@@ -1,55 +1,109 @@
 import asyncio
-from typing import TypeVar, Type, Dict
+from typing import Dict, Optional, Type, TypeVar
 
 import aiohttp
-from aiohttp import ClientSession, ClientResponse
+from aiohttp import ClientResponse, ClientSession
+from aiohttp_retry import ExponentialRetry, RetryClient
 from pydantic.tools import parse_raw_as
-from traveltimepy.dto.requests.request import TravelTimeRequest
 
+from traveltimepy.dto.requests.request import TravelTimeRequest
 from traveltimepy.dto.responses.error import ResponseError
 from traveltimepy.errors import ApiError
-from aiohttp_retry import RetryClient, ExponentialRetry
+from traveltimepy.utils.throttler import Throttler
+from traveltimepy.utils.utils import count_api_hits
 
 T = TypeVar('T')
 R = TypeVar('R')
 
+try:
+    from loguru import logger
+except ImportError:
+    import logging
 
+    logger = logging.getLogger(__name__)
+
+
+# new function to send a POST request asynchronously to avoid
+# duplicating this code inside the send_post_request_async function
+async def _execute_post_request_async(
+    client: RetryClient,
+    response_class: Type[T],
+    path: str,
+    headers: dict[str, str],
+    request: TravelTimeRequest,
+) -> T:
+    # Construct the URL for the API endpoint
+    url = f"https://api.traveltimeapp.com/v4/{path}"
+    # Send a POST request to the API with the given headers and data
+    print(request.json())
+    try:
+        async with client.post(url=url, headers=headers, data=request.json()) as resp:
+            # Process the response and return it as an instance of the given response class
+            return await __process_response(response_class, resp)
+    except Exception as e:
+        logger.error(f"Error sending POST request to {url}: {e}")
+        raise e
+
+
+# update the send_post_request_async function to support use of a Throttler
 async def send_post_request_async(
     client: RetryClient,
     response_class: Type[T],
     path: str,
-    headers: Dict[str, str],
-    request: TravelTimeRequest
+    headers: dict[str, str],
+    request: TravelTimeRequest,
+    throttler: Optional[Throttler] = None,
 ) -> T:
-    url = f'https://api.traveltimeapp.com/v4/{path}'
-    async with client.post(url=url, headers=headers, data=request.json()) as resp:
-        return await __process_response(response_class, resp)
+    # If no throttler is provided, just send the POST request without throttling
+    if throttler is None:
+        return await _execute_post_request_async(client, response_class, path, headers, request)
+    else:
+        # Otherwise, use the throttler to enforce the request rate limit before sending the POST request
+        async with throttler.use(count_api_hits(request)):
+            return await _execute_post_request_async(
+                client, response_class, path, headers, request
+            )
 
 
+# update the send_post_async function to support use of a Throttler
 async def send_post_async(
     response_class: Type[T],
     path: str,
-    headers: Dict[str, str],
+    headers: dict[str, str],
     request: TravelTimeRequest,
-    limit_per_host: int
+    limit_per_host: int,
+    throttler: Optional[Throttler] = None,
 ) -> T:
     connector = aiohttp.TCPConnector(verify_ssl=False, limit_per_host=limit_per_host)
-    async with ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=60 * 60 * 30)) as session:
-        client = RetryClient(client_session=session, retry_options=ExponentialRetry(attempts=3))
-        tasks = [send_post_request_async(client, response_class, path, headers, part) for part in request.split_searches()]
+    async with ClientSession(
+        connector=connector, timeout=aiohttp.ClientTimeout(total=60 * 60 * 30)
+    ) as session:
+        client = RetryClient(
+            client_session=session, retry_options=ExponentialRetry(attempts=3), logger=logger
+        )
+        parts = request.split_searches()
+        logger.debug(f"Split {request.__class__.__name__} request into {len(parts)} parts.")
+        tasks = [
+            send_post_request_async(client, response_class, path, headers, part, throttler)
+            for part in parts
+        ]
         responses = await asyncio.gather(*tasks)
         await client.close()
         return request.merge(responses)
 
 
+# update the send_post function to support use of a Throttler
 def send_post(
     response_class: Type[T],
     path: str,
-    headers: Dict[str, str],
+    headers: dict[str, str],
     request: TravelTimeRequest,
-    limit_per_host: int
+    limit_per_host: int,
+    throttler: Optional[Throttler] = None,
 ) -> T:
-    return asyncio.run(send_post_async(response_class, path, headers, request, limit_per_host))
+    return asyncio.run(
+        send_post_async(response_class, path, headers, request, limit_per_host, throttler)
+    )
 
 
 async def send_get_async(

--- a/traveltimepy/utils/throttler.py
+++ b/traveltimepy/utils/throttler.py
@@ -1,0 +1,104 @@
+import asyncio
+from collections import deque
+from contextlib import asynccontextmanager
+
+try:
+    from loguru import logger
+except ImportError:
+    from logging import getLogger
+
+    logger = getLogger(__name__)
+
+
+class Throttler:
+    """Simple throttler for asyncio"""
+
+    def __init__(
+        self,
+        rate_limit: int,
+        time_window: int,
+        retry_interval=0.001,
+        loop=None,
+    ):
+        self.time_window = time_window
+        self.rate_limit = rate_limit
+        self.retry_interval = retry_interval
+
+        # Set the event loop to the one passed in, or the default asyncio event loop if none is passed.
+        self.loop = loop or asyncio.get_event_loop()
+
+        # Create a new deque object to store task start times.
+        self._task_logs = deque()
+
+    def remove_expired_tasks(self):
+        # Get the current time from the event loop
+        now = self.loop.time()
+
+        # Remove items (which are start times) that are no longer in the time window
+        # Check if the deque containing task start times is not empty.
+        while self._task_logs:
+            # Calculate the time difference between the current time and the first task start time in the deque,
+            # and check whether it's greater than the rate interval length.
+            if now - self._task_logs[0] > self.time_window:
+                # Remove the first(start time) item from the deque since it's no longer needed.
+                self._task_logs.popleft()
+            else:
+                # If the first item in the deque is still within the time window, break out of the while loop.
+                break
+
+    async def __aenter__(self):
+        await self.wait_for_availability()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        # nothing to do here
+        pass
+
+    async def wait_for_availability(self, num_requests: int = 1):
+        # Start an infinite loop
+        while True:
+            # get rid of items that don't have to be tracked anymore
+            self.remove_expired_tasks()
+
+            # Exit the infinite loop when new task can be processed
+            # Check if the task log can accommodate the new task.
+            if len(self._task_logs) + num_requests <= self.rate_limit:
+                break  # If the rate limit hasn't been reached yet, break out of the infinite loop.
+
+            # calculate the time we have to wait until the task can be processed
+            space_available = self.rate_limit - len(self._task_logs)
+            space_missing = num_requests - space_available
+            last_task_that_has_to_be_removed = self._task_logs[space_missing - 1]
+            time_to_wait = max(
+                self.retry_interval,
+                last_task_that_has_to_be_removed + self.time_window - self.loop.time(),
+            )
+
+            logger.debug(
+                f"{space_available} available\t"
+                f"{space_missing} more needed\t"
+                f"Waiting {int(time_to_wait)} s..."
+            )
+
+            # If the rate limit has been reached, use asyncio.sleep to
+            # suspend this coroutine for a short time before trying again.
+            await asyncio.sleep(time_to_wait)
+
+        # Push new task's start time
+        # If the rate limit hasn't been reached, add the current time as a new start time to the deque.
+        time = self.loop.time()
+        self._task_logs.extend([time for _ in range(num_requests)])
+
+        logger.debug(
+            f"Current Rate: "
+            f"{len(self._task_logs)} / {self.rate_limit} per {self.time_window} s"
+        )
+
+    # Define the async context manager enter method
+    @asynccontextmanager
+    async def use(self, num_requests: int = 1):
+        """Implementation as context manager method to allow for passing of num_requests parameter"""
+
+        await self.wait_for_availability(num_requests)
+
+        yield self  # Return the Throttler object itself as the result of the async context manager enter method.

--- a/traveltimepy/utils/utils.py
+++ b/traveltimepy/utils/utils.py
@@ -1,0 +1,8 @@
+from traveltimepy.dto.requests.request import TravelTimeRequest
+from traveltimepy.dto.requests.time_filter import TimeFilterRequest
+
+
+def count_api_hits(request: TravelTimeRequest) -> int:
+    if isinstance(request, TimeFilterRequest):
+        return len(request.departure_searches) + len(request.arrival_searches)
+    raise TypeError(f"Unsupported request type: {type(request)}")

--- a/traveltimepy/utils/utils.py
+++ b/traveltimepy/utils/utils.py
@@ -1,8 +1,0 @@
-from traveltimepy.dto.requests.request import TravelTimeRequest
-from traveltimepy.dto.requests.time_filter import TimeFilterRequest
-
-
-def count_api_hits(request: TravelTimeRequest) -> int:
-    if isinstance(request, TimeFilterRequest):
-        return len(request.departure_searches) + len(request.arrival_searches)
-    raise TypeError(f"Unsupported request type: {type(request)}")


### PR DESCRIPTION
I created a suggestion on how to implement a throttling feature using an optional parameter `throttler` to the TravelTimeSdk class.

As the API accepts multiple searches in one request we need to calculate the number of searches/hits per request.
I implemented an `api_hits_count` which defaults to `1` and only added a real implementation to the `TravelTimeFilterRequest` class as I am not that familiar with the other ones.