### PR TITLE
Consistently require max_changes to be of type Optiona[MaxChanges] and expose the type publically.

### DIFF
--- a/traveltimepy/__init__.py
+++ b/traveltimepy/__init__.py
@@ -7,6 +7,7 @@ from traveltimepy.dto.transportation import (
     Walking,
     Cycling,
     DrivingTrain,
+    MaxChanges
 )
 from traveltimepy.dto.requests.time_filter_proto import (
     ProtoTransportation,

--- a/traveltimepy/dto/transportation.py
+++ b/traveltimepy/dto/transportation.py
@@ -41,4 +41,4 @@ class PublicTransport(BaseModel):
     type: Literal["public_transport", "train", "bus", "coach"] = "public_transport"
     pt_change_delay: Optional[int] = None
     walking_time: Optional[int] = None
-    max_changes: Optional[int] = None
+    max_changes: Optional[MaxChanges] = None


### PR DESCRIPTION
Currently when I try to use max_changes in the PublicTransport object as is I get the following error:

traveltimepy.errors.ApiError: Travel Time API request failed: Invalid request json
Error code: 2
Additional info: {'obj.arrival_searches[0].transportation.max_changes.enabled': ['Path missing']}