### PR TITLE
Fixed partially wrong GEOJSON implementation

### DIFF
--- a/traveltimepy/dto/requests/time_map.py
+++ b/traveltimepy/dto/requests/time_map.py
@@ -71,8 +71,8 @@ class Union(BaseModel):
 class TimeMapRequest(TravelTimeRequest[TimeMapResponse]):
     departure_searches: List[DepartureSearch]
     arrival_searches: List[ArrivalSearch]
-    unions: List[Union]
-    intersections: List[Intersection]
+    unions: List[Union] = None
+    intersections: List[Intersection] = None
 
     def split_searches(self, window_size: int) -> List[TravelTimeRequest]:
         return [

--- a/traveltimepy/dto/requests/time_map_geojson.py
+++ b/traveltimepy/dto/requests/time_map_geojson.py
@@ -19,6 +19,7 @@ from traveltimepy import (
     LevelOfDetail,
 )
 from traveltimepy.dto.requests.request import TravelTimeRequest
+from traveltimepy.dto.requests.time_map import TimeMapRequest
 from traveltimepy.itertools import split, flatten
 
 
@@ -62,10 +63,9 @@ class TimeMapRequestGeojson(TravelTimeRequest[FeatureCollection]):
     departure_searches: List[DepartureSearch]
     arrival_searches: List[ArrivalSearch]
 
-    def split_searches(self, window_size: int) -> List[FeatureCollection]:
+    def split_searches(self, window_size: int) -> List[TravelTimeRequest]:
         return [
-            FeatureCollection(
-                type="FeatureCollection",
+            TimeMapRequest(
                 departure_searches=departures,
                 arrival_searches=arrivals,
             )

--- a/traveltimepy/http.py
+++ b/traveltimepy/http.py
@@ -71,38 +71,6 @@ async def send_post_async(
             return request.merge(responses)
 
 
-async def send_post_geojson_async(
-    response_class: Type[T],
-    path: str,
-    headers: Dict[str, str],
-    request: TravelTimeRequest,
-    sdk_params: SdkParams,
-) -> T:
-    window_size = _window_size(sdk_params.rate_limit)
-    async with ClientSession(
-        connector=TCPConnector(ssl=False, limit_per_host=sdk_params.limit_per_host)
-    ) as session:
-        retry_options = ExponentialRetry(attempts=sdk_params.retry_attempts)
-        async with RetryClient(
-            client_session=session, retry_options=retry_options
-        ) as client:
-            rate_limit = AsyncLimiter(
-                sdk_params.rate_limit // window_size, sdk_params.time_window
-            )
-            tasks = [
-                send_post_request_async(
-                    client,
-                    response_class,
-                    f"https://{sdk_params.host}/v4/{path}",
-                    headers,
-                    request,
-                    rate_limit,
-                )
-            ]
-            responses = await asyncio.gather(*tasks)
-            return request.merge(responses)
-
-
 def _window_size(rate_limit: int):
     if rate_limit >= DEFAULT_SPLIT_SIZE:
         return DEFAULT_SPLIT_SIZE

--- a/traveltimepy/sdk.py
+++ b/traveltimepy/sdk.py
@@ -69,7 +69,6 @@ from traveltimepy.http import (
     send_get_async,
     send_post_async,
     SdkParams,
-    send_post_geojson_async,
 )
 
 from geojson_pydantic import FeatureCollection
@@ -505,7 +504,7 @@ class TravelTimeSdk:
         search_range: Optional[Range] = None,
         level_of_detail: Optional[LevelOfDetail] = None,
     ) -> FeatureCollection:
-        resp = await send_post_geojson_async(
+        resp = await send_post_async(
             FeatureCollection,
             "time-map",
             self._headers(AcceptType.GEO_JSON),


### PR DESCRIPTION
My previous geojson time-map request was wrong since it wasn't even using the `split_searches` method that I managed to avoid accidentally.

Also defaulted `unions` and `intersections` in `TimeMapRequest` to `None` since I'm not implementing them for now.