### PR TITLE
Adding hyperlinks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Given origin coordinates, find shapes of zones reachable within corresponding tr
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 3600
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * search_range: Range - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
-* level_of_detail: LevelOfDetail - When enabled, allows the user to specify how detailed the isochrones should be.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [level_of_detail](#level-of-detail): LevelOfDetail - When enabled, allows the user to specify how detailed the isochrones should be.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 ### JSON response
 
@@ -203,10 +203,10 @@ Given origin coordinates, find intersections of specified shapes.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 3600
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * search_range: Range - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -248,10 +248,10 @@ Finds the union of specified shapes.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 3600
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * search_range: Range - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -292,9 +292,9 @@ Given origin coordinates, find shapes of zones reachable within corresponding tr
   arrival_time.
 * travel_distance: int - Maximum journey distance (in meters). Maximum value is 800000 (800km). Minimum value is 75. 
   Default value is 900.
-* transportation: Union - Transportation mode and related parameters.
-* level_of_detail: LevelOfDetail - When enabled, allows the user to specify how detailed the isochrones should be.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
+* [level_of_detail](#level-of-detail): LevelOfDetail - When enabled, allows the user to specify how detailed the isochrones should be.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -336,12 +336,13 @@ travel times, distances and costs between an origin and up to 2,000 destination 
 * arrival_time: datetime - Be at arrival location at no later than given time. Cannot be specified with departure_time.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 3600.
 * properties: List[Property] - Properties to be returned about the points. Default value is travel_time.
 * range: FullRange - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
 * snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -393,12 +394,12 @@ A very fast version of `time_filter()`. However, the request parameters are much
 * locations: List[Locations] - All locations. Location ids must be unique.
 * search_ids: Dict[str, List[str]] - Searches from a target location to destinations. You can define up to 100,000
   destinations
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 10800. Default value is 3600.
 * properties: List[Property] - Properties to be returned about the points. Default value is travel_time.
 * one_to_many: boolean - if one_to_many is equal to true, then it'll be a forward search (one to many matrix), false -
   backward search (many to one matrix). Default value is True.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -497,11 +498,11 @@ Returns routing information between source and destinations.
 * arrival_time: datetime - Be at arrival location at no later than given time. Cannot be specified with departure_time.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * properties: List[Property] - Properties to be returned about the locations. Default value is travel_time.
 * range: FullRange - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
-* snapping: Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
+* [snapping](#snapping): Snapping - Adjusts the process of looking up the nearest roads from the departure / arrival points.
 
 #### Returns:
 
@@ -609,7 +610,7 @@ supports United Kingdom.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 1800
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * properties: List[Property] - Properties to be returned about the postcodes. Default value is travel_time.
 * range: FullRange - When enabled, range adds an arrival window to the arrival time, and results are returned for any
   journeys that arrive during this window.
@@ -651,7 +652,7 @@ such districts. Currently only supports United Kingdom.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 1800
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * reachable_postcodes_threshold: float - A number between 0.0 and 1.0. Default value is 0.1. For example, if 0.5 is
   used, only districts that have at least 50% postcodes that can be reached within the given travel_time will be
   included in the response. 0 will return districts that have at least a single reachable postcode.
@@ -697,7 +698,7 @@ sectors. Currently only supports United Kingdom.
 * departure_time: datetime - Leave departure location at no earlier than given time. Cannot be specified with
   arrival_time.
 * travel_time: int - Maximum journey time (in seconds). Maximum value is 14400. Default value is 1800
-* transportation: Union - Transportation mode and related parameters.
+* [transportation](#transportation): Union - Transportation mode and related parameters.
 * reachable_postcodes_threshold: float - A number between 0.0 and 1.0. Default value is 0.1. For example, if 0.5 is
   used, only sectors that have at least 50% postcodes that can be reached within the given travel_time will be included
   in the response. 0 will return sectors that have at least a single reachable postcode.


### PR DESCRIPTION
As discussed here https://github.com/traveltime-dev/traveltime-python-sdk/pull/122#discussion_r1636420968, I'm adding hyperlinks for the more complex usage params. We already have a link pointing to the docs on the endpoint header, so I thought it would be nice just to add a hyperlink to the readme section describing the usage of that param.

In the future I'm planning to add usage examples to more params.

Not bumping version here, since it was bumped in the last PR, I'll make a single release after this one.