### PR TITLE
Adding back MaxChanges to __init__.py

### DIFF
--- a/traveltimepy/__init__.py
+++ b/traveltimepy/__init__.py
@@ -16,6 +16,7 @@ from traveltimepy.dto.transportation import (
     Cycling,
     DrivingTrain,
     CyclingPublicTransport,
+    MaxChanges,
 )
 from traveltimepy.dto.requests.time_filter_proto import (
     ProtoTransportation,
@@ -45,6 +46,7 @@ __all__ = [
     "Cycling",
     "DrivingTrain",
     "CyclingPublicTransport",
+    "MaxChanges",
     "ProtoTransportation",
     "ProtoCountry",
     "Coordinates",


### PR DESCRIPTION
https://github.com/traveltime-dev/traveltime-python-sdk/commit/4495253e12d84fdb6fd598971ef938a835c28f75#diff-ea67cbaf84c799a0cdde03342777b488b32824f2f7107e5cee354c3e35a5be04L11 In this PR, as pointed out to me by @SimonasJa, I removed `MaxChanges` from `__init__.py`, because the stricter type checking was complaining. This ended up leading to this error when trying to import it:
```
ImportError: cannot import name 'MaxChanges' from 'traveltimepy'
```

Instead of removing it, I should have fixed the missing import for `MaxChanges`. 