### PR TITLE
Adding py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include traveltimepy/py.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.md
-include traveltimepy/py.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+recursive-include traveltimepy *.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.md
-recursive-include traveltimepy *.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
 zip-safe = false
 include-package-data = true
 packages = { find = {} }
-package-data = { "traveltimepy" = ["py.typed"] }
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ test = [
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-packages = { find = {} }
-package-data = { "traveltimepy" = ["py.typed"] }
+packages = ['traveltime']
+package-data = { 'traveltime' = ['py.typed'] }
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,9 @@ test = [
 zip-safe = false
 include-package-data = true
 packages = { find = {} }
+package-data = { "traveltimepy" = ["py.typed"] }
 
 [tool.setuptools_scm]
-
-[tool.setuptools.package-data]
-"traveltimepy" = ["py.typed"]
 
 [tool.flake8]
 per-file-ignores = ["**/__init__.py:F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ test = [
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-packages = ['traveltime']
-package-data = { 'traveltime' = ['py.typed'] }
+packages = { find = {} }
+package-data = { "traveltimepy" = ["py.typed"] }
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ packages = { find = {} }
 
 [tool.setuptools_scm]
 
+[tool.setuptools.package-data]
+"traveltimepy" = ["py.typed"]
+
 [tool.flake8]
 per-file-ignores = ["**/__init__.py:F401"]
 max-line-length = 88


### PR DESCRIPTION
Related to: https://github.com/traveltime-dev/traveltime-python-sdk/issues/133

When trying to improve CI for `traveltime-google-comparison` tool, I noticed that `traveltimepy` doesn't work with `mypy` type checking, even tho it should, since we specify types everywhere. With this change, type checking for traveltimepy should (at least mostly) work by default for everyone.

Same thing done in pydantic: https://github.com/pydantic/pydantic/pull/391 (don't need to specify it in `pyproject.toml`, because the `include-package-data = true` flag already picks it up in my testing)
