### PR TITLE
Fixing incorrect Routes model

### DIFF
--- a/traveltimepy/dto/common.py
+++ b/traveltimepy/dto/common.py
@@ -35,7 +35,7 @@ class Location(BaseModel):
 
 
 class BasicPart(BaseModel):
-    id: str
+    id: int
     mode: str
     directions: str
     distance: int
@@ -45,7 +45,7 @@ class BasicPart(BaseModel):
 
 
 class RoadPart(BaseModel):
-    id: str
+    id: int
     mode: str
     directions: str
     distance: int
@@ -57,7 +57,7 @@ class RoadPart(BaseModel):
 
 
 class StartEndPart(BaseModel):
-    id: str
+    id: int
     mode: str
     directions: str
     distance: int
@@ -68,7 +68,7 @@ class StartEndPart(BaseModel):
 
 
 class PublicTransportPart(BaseModel):
-    id: str
+    id: int
     mode: str
     directions: str
     distance: int
@@ -135,9 +135,9 @@ class SnappingAcceptRoads(str, Enum):
 
 class Snapping(BaseModel):
     penalty: Optional[SnappingPenalty] = SnappingPenalty.ENABLED
-    accept_roads: Optional[SnappingAcceptRoads] = (
-        SnappingAcceptRoads.BOTH_DRIVABLE_AND_WALKABLE
-    )
+    accept_roads: Optional[
+        SnappingAcceptRoads
+    ] = SnappingAcceptRoads.BOTH_DRIVABLE_AND_WALKABLE
 
 
 class PropertyProto(int, Enum):

--- a/traveltimepy/dto/common.py
+++ b/traveltimepy/dto/common.py
@@ -135,9 +135,9 @@ class SnappingAcceptRoads(str, Enum):
 
 class Snapping(BaseModel):
     penalty: Optional[SnappingPenalty] = SnappingPenalty.ENABLED
-    accept_roads: Optional[
-        SnappingAcceptRoads
-    ] = SnappingAcceptRoads.BOTH_DRIVABLE_AND_WALKABLE
+    accept_roads: Optional[SnappingAcceptRoads] = (
+        SnappingAcceptRoads.BOTH_DRIVABLE_AND_WALKABLE
+    )
 
 
 class PropertyProto(int, Enum):


### PR DESCRIPTION
When adding the `Property.ROUTE` to time-filter requests, model validation failed, as the ids are all ints, and pydantic does not handle this by default. I changed it to `int`, but I can probably make smth like `Union[str, int]` as well.

Thanks @SimonasJa for finding this