### PR TITLE
Updating supported proto countries list

### DIFF
--- a/traveltimepy/dto/requests/time_filter_proto.py
+++ b/traveltimepy/dto/requests/time_filter_proto.py
@@ -47,3 +47,8 @@ class ProtoCountry(str, Enum):
     ITALY = "it"
     POLAND = "pl"
     SWEDEN = "se"
+    LIECHTENSTEIN = "li"
+    MEXICO = "mx"
+    SAUDI_ARABIA = "sa"
+    SERBIA = "rs"
+    SLOVENIA = "si"


### PR DESCRIPTION
Updated missing countries from this list https://docs.traveltime.com/api/overview/supported-countries