### PR TITLE
CI: disable persist-credentials for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           - "3.12"
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
It is a possible security issue.
We do not want to persist credentials in the repo and thus exposing those to further steps.

References:

https://github.com/actions/checkout/issues/485#issuecomment-1197047674 https://github.com/azat/chdig/pull/67