### PR TITLE
Removing default values from request DTOs

### DIFF
--- a/traveltimepy/dto/requests/distance_map.py
+++ b/traveltimepy/dto/requests/distance_map.py
@@ -36,10 +36,10 @@ class DepartureSearch(BaseModel):
         DrivingTrain,
         CyclingPublicTransport,
     ]
-    level_of_detail: Optional[LevelOfDetail] = None
-    snapping: Optional[Snapping] = None
-    polygons_filter: Optional[PolygonsFilter] = None
-    no_holes: Optional[bool] = None
+    level_of_detail: Optional[LevelOfDetail]
+    snapping: Optional[Snapping]
+    polygons_filter: Optional[PolygonsFilter]
+    no_holes: Optional[bool]
 
 
 class ArrivalSearch(BaseModel):
@@ -56,10 +56,10 @@ class ArrivalSearch(BaseModel):
         DrivingTrain,
         CyclingPublicTransport,
     ]
-    level_of_detail: Optional[LevelOfDetail] = None
-    snapping: Optional[Snapping] = None
-    polygons_filter: Optional[PolygonsFilter] = None
-    no_holes: Optional[bool] = None
+    level_of_detail: Optional[LevelOfDetail]
+    snapping: Optional[Snapping]
+    polygons_filter: Optional[PolygonsFilter]
+    no_holes: Optional[bool]
 
 
 class Intersection(BaseModel):

--- a/traveltimepy/dto/requests/postcodes.py
+++ b/traveltimepy/dto/requests/postcodes.py
@@ -33,7 +33,7 @@ class ArrivalSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
+    range: Optional[FullRange]
 
 
 class DepartureSearch(BaseModel):
@@ -51,7 +51,7 @@ class DepartureSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
+    range: Optional[FullRange]
 
 
 class PostcodesRequest(TravelTimeRequest[PostcodesResponse]):

--- a/traveltimepy/dto/requests/postcodes_zones.py
+++ b/traveltimepy/dto/requests/postcodes_zones.py
@@ -44,7 +44,7 @@ class ArrivalSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[ZonesProperty]
-    range: Optional[FullRange] = None
+    range: Optional[FullRange]
 
 
 class DepartureSearch(BaseModel):
@@ -63,7 +63,7 @@ class DepartureSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[ZonesProperty]
-    range: Optional[FullRange] = None
+    range: Optional[FullRange]
 
 
 class PostcodesSectorsRequest(TravelTimeRequest[PostcodesSectorsResponse]):

--- a/traveltimepy/dto/requests/routes.py
+++ b/traveltimepy/dto/requests/routes.py
@@ -33,8 +33,8 @@ class ArrivalSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
-    snapping: Optional[Snapping] = None
+    range: Optional[FullRange]
+    snapping: Optional[Snapping]
 
 
 class DepartureSearch(BaseModel):
@@ -52,8 +52,8 @@ class DepartureSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
-    snapping: Optional[Snapping] = None
+    range: Optional[FullRange]
+    snapping: Optional[Snapping]
 
 
 class RoutesRequest(TravelTimeRequest[RoutesResponse]):

--- a/traveltimepy/dto/requests/time_filter.py
+++ b/traveltimepy/dto/requests/time_filter.py
@@ -34,8 +34,8 @@ class ArrivalSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
-    snapping: Optional[Snapping] = None
+    range: Optional[FullRange]
+    snapping: Optional[Snapping]
 
 
 class DepartureSearch(BaseModel):
@@ -54,8 +54,8 @@ class DepartureSearch(BaseModel):
         CyclingPublicTransport,
     ]
     properties: List[Property]
-    range: Optional[FullRange] = None
-    snapping: Optional[Snapping] = None
+    range: Optional[FullRange]
+    snapping: Optional[Snapping]
 
 
 class TimeFilterRequest(TravelTimeRequest[TimeFilterResponse]):

--- a/traveltimepy/dto/requests/time_filter_fast.py
+++ b/traveltimepy/dto/requests/time_filter_fast.py
@@ -30,7 +30,7 @@ class OneToMany(BaseModel):
     travel_time: int
     arrival_time_period: str
     properties: List[Property]
-    snapping: Optional[Snapping] = None
+    snapping: Optional[Snapping]
 
 
 class ManyToOne(BaseModel):
@@ -41,7 +41,7 @@ class ManyToOne(BaseModel):
     travel_time: int
     arrival_time_period: str
     properties: List[Property]
-    snapping: Optional[Snapping] = None
+    snapping: Optional[Snapping]
 
 
 class ArrivalSearches(BaseModel):

--- a/traveltimepy/dto/requests/time_map.py
+++ b/traveltimepy/dto/requests/time_map.py
@@ -37,8 +37,8 @@ class DepartureSearch(BaseModel):
         DrivingTrain,
         CyclingPublicTransport,
     ]
-    range: Optional[Range] = None
-    level_of_detail: Optional[LevelOfDetail] = None
+    range: Optional[Range]
+    level_of_detail: Optional[LevelOfDetail]
     snapping: Optional[Snapping]
     polygons_filter: Optional[PolygonsFilter]
     remove_water_bodies: Optional[bool]
@@ -59,9 +59,9 @@ class ArrivalSearch(BaseModel):
         DrivingTrain,
         CyclingPublicTransport,
     ]
-    range: Optional[Range] = None
-    level_of_detail: Optional[LevelOfDetail] = None
-    snapping: Optional[Snapping] = None
+    range: Optional[Range]
+    level_of_detail: Optional[LevelOfDetail]
+    snapping: Optional[Snapping]
     polygons_filter: Optional[PolygonsFilter]
     remove_water_bodies: Optional[bool]
     render_mode: Optional[RenderMode]

--- a/traveltimepy/dto/requests/time_map_fast.py
+++ b/traveltimepy/dto/requests/time_map_fast.py
@@ -22,7 +22,7 @@ class Search(BaseModel):
     travel_time: int
     arrival_time_period: str
     level_of_detail: Optional[LevelOfDetail]
-    snapping: Optional[Snapping] = None
+    snapping: Optional[Snapping]
     polygons_filter: Optional[PolygonsFilter]
     render_mode: Optional[RenderMode]
 

--- a/traveltimepy/mapper.py
+++ b/traveltimepy/mapper.py
@@ -685,6 +685,7 @@ def create_time_map_wkt(
                     travel_time=travel_time,
                     departure_time=time_info.value,
                     transportation=transportation,
+                    level_of_detail=level_of_detail,
                     range=search_range,
                     snapping=snapping,
                     polygons_filter=polygons_filter,

--- a/traveltimepy/mapper.py
+++ b/traveltimepy/mapper.py
@@ -284,7 +284,7 @@ def create_time_filter_fast(
     locations: List[Location],
     search_ids: Dict[str, List[str]],
     transportation: Transportation,
-    travel_time: int = 3600,
+    travel_time: int,
     properties: Optional[List[Property]],
     one_to_many: bool,
     snapping: Optional[Snapping],

--- a/traveltimepy/mapper.py
+++ b/traveltimepy/mapper.py
@@ -76,7 +76,7 @@ def create_time_filter(
     time_info: TimeInfo,
     travel_time: int,
     range: Optional[FullRange],
-    snapping: Optional[Snapping] = None,
+    snapping: Optional[Snapping],
 ) -> TimeFilterRequest:
     if properties is None:
         properties = [Property.TRAVEL_TIME]
@@ -285,9 +285,9 @@ def create_time_filter_fast(
     search_ids: Dict[str, List[str]],
     transportation: Transportation,
     travel_time: int = 3600,
-    properties: Optional[List[Property]] = None,
-    one_to_many: bool = True,
-    snapping: Optional[Snapping] = None,
+    properties: Optional[List[Property]],
+    one_to_many: bool,
+    snapping: Optional[Snapping],
 ) -> TimeFilterFastRequest:
     if properties is None:
         properties = [Property.TRAVEL_TIME]
@@ -985,7 +985,7 @@ def create_proto_request(
     transportation: ProtoTransportation,
     properties: Optional[List[PropertyProto]],
     travel_time: int,
-    one_to_many: bool = True,
+    one_to_many: bool,
 ) -> TimeFilterFastRequest_pb2.TimeFilterFastRequest:  # type: ignore
     request = TimeFilterFastRequest_pb2.TimeFilterFastRequest()  # type: ignore
 


### PR DESCRIPTION
Having default values in request DTOs is bug prone - type checker will not tell us if we forget to set a param.

Also removed default values from the `mapper` class.

None of these changes should be breaking changes, the only functions the client is supposed to be using are in `sdk.py`