### PR TITLE
Fix type checker error

### DIFF
--- a/tests/time_map_fast_test.py
+++ b/tests/time_map_fast_test.py
@@ -44,7 +44,7 @@ async def test_one_to_many_geojson(sdk: TravelTimeSdk):
         transportation=Transportation(type="public_transport"),
     )
 
-    assert len(results) == 2
+    assert len(results.features) == 2
 
 
 @pytest.mark.asyncio
@@ -59,7 +59,7 @@ async def test_many_to_one_geojson(sdk: TravelTimeSdk):
         one_to_many=False,
     )
 
-    assert len(results) == 2
+    assert len(results.features) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/time_map_test.py
+++ b/tests/time_map_test.py
@@ -33,7 +33,7 @@ async def test_departures_geojson(sdk: TravelTimeSdk):
         search_range=Range(enabled=True, width=1800),
         level_of_detail=LevelOfDetail(scale_type="simple", level="lowest"),
     )
-    assert len(results) == 2
+    assert len(results.features) == 2
 
 
 @pytest.mark.asyncio
@@ -97,7 +97,7 @@ async def test_arrivals_geojson(sdk: TravelTimeSdk):
         search_range=Range(enabled=True, width=1800),
         level_of_detail=LevelOfDetail(scale_type="simple", level="lowest"),
     )
-    assert len(results) == 2
+    assert len(results.features) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Type checker started complaining for python v3.9+ about using `len()` directly on a `FeatureCollection`