### PR TITLE
Include proto generated files in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ test = [
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
+py-modules = [
+    "RequestsCommon_pb2",
+    "TimeFilterFastRequest_pb2", 
+    "TimeFilterFastResponse_pb2"
+]
 packages = { find = {} }
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Latest release broke proto - I moved proto generated output to root dir, but they do not end up in the `traveltimepy` package.

```zsh
(env) ➜  pythontest python3 test.py
Traceback (most recent call last):
  File "/home/arnas/pythontest/test.py", line 2, in <module>
    from traveltimepy import (
  File "/home/arnas/pythontest/env/lib/python3.11/site-packages/traveltimepy/__init__.py", line 41, in <module>
    from traveltimepy.sdk import TravelTimeSdk
  File "/home/arnas/pythontest/env/lib/python3.11/site-packages/traveltimepy/sdk.py", line 70, in <module>
    from traveltimepy.mapper import (
  File "/home/arnas/pythontest/env/lib/python3.11/site-packages/traveltimepy/mapper.py", line 15, in <module>
    import TimeFilterFastRequest_pb2  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'TimeFilterFastRequest_pb2'
```

There might be better ways to do this, but for now this should work