### PR TITLE
Refactoring fast transportation to properly support traffic_model

### DIFF
--- a/benchmarks/time_filter_fast.py
+++ b/benchmarks/time_filter_fast.py
@@ -3,12 +3,12 @@ import time
 
 from benchmarks.common import generate_locations
 from traveltimepy.requests.common import Property
-from traveltimepy.requests.transportation import TransportationFast
 from traveltimepy.async_client import AsyncClient
 from traveltimepy.requests.time_filter_fast import (
     TimeFilterFastArrivalSearches,
     TimeFilterFastOneToMany,
 )
+from traveltimepy.requests.transportation import DrivingFerryFast, FastTrafficModel
 
 
 async def generate_matrix(size: int):
@@ -22,7 +22,7 @@ async def generate_matrix(size: int):
                 arrival_location_ids=list(
                     filter(lambda cur_id: cur_id != location_id, location_ids)
                 ),
-                transportation=TransportationFast.DRIVING,
+                transportation=DrivingFerryFast(traffic_model=FastTrafficModel.PEAK),
                 travel_time=3600,
                 properties=[Property.TRAVEL_TIME],
             )

--- a/examples/time_filter_fast_matrix.py
+++ b/examples/time_filter_fast_matrix.py
@@ -30,7 +30,7 @@ from traveltimepy.requests.time_filter_fast import (
     TimeFilterFastArrivalSearches,
     TimeFilterFastOneToMany,
 )
-from traveltimepy.requests.transportation import TransportationFast
+from traveltimepy.requests.transportation import PublicTransportFast
 
 import numpy as np
 
@@ -93,7 +93,7 @@ def create_fast_searches(locations, properties=None):
             departure_location_id=origin.id,
             arrival_location_ids=location_ids,
             travel_time=7200,
-            transportation=TransportationFast.PUBLIC_TRANSPORT,
+            transportation=PublicTransportFast(),
             properties=properties,
             arrival_time_period=ArrivalTimePeriod.WEEKDAY_MORNING,
         )

--- a/tests/geohash_fast_test.py
+++ b/tests/geohash_fast_test.py
@@ -9,7 +9,11 @@ from traveltimepy.requests.geohash_fast import (
     GeoHashFastUnion,
     GeoHashFastIntersection,
 )
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    DrivingFerryFast,
+    FastTrafficModel,
+    PublicTransportFast,
+)
 
 
 @pytest.mark.asyncio
@@ -20,13 +24,13 @@ async def test_one_to_many(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -50,13 +54,13 @@ async def test_many_to_one(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -77,13 +81,13 @@ def test_one_to_many_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -106,13 +110,13 @@ def test_many_to_one_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -134,9 +138,10 @@ async def test_one_to_many_with_traffic_model(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -159,9 +164,10 @@ async def test_many_to_one_with_traffic_model(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
         ),
@@ -181,9 +187,10 @@ def test_one_to_many_with_traffic_model_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -205,9 +212,10 @@ def test_many_to_one_with_traffic_model_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
         ),
@@ -228,13 +236,13 @@ async def test_union_one_to_many(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -257,13 +265,13 @@ async def test_intersection_many_to_one(async_client: AsyncClient):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -287,13 +295,13 @@ def test_union_one_to_many_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -315,13 +323,13 @@ def test_intersection_many_to_one_sync(client: Client):
                 GeoHashFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 GeoHashFastSearch(
                     id="id 2",
                     coords=GeohashCentroid(geohash_centroid="gcpvj3"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],

--- a/tests/h3_fast_test.py
+++ b/tests/h3_fast_test.py
@@ -9,7 +9,11 @@ from traveltimepy.requests.h3_fast import (
     H3FastUnion,
     H3FastIntersection,
 )
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    DrivingFerryFast,
+    FastTrafficModel,
+    PublicTransportFast,
+)
 
 
 @pytest.mark.asyncio
@@ -20,13 +24,13 @@ async def test_one_to_many(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -49,13 +53,13 @@ async def test_many_to_one(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -77,13 +81,13 @@ def test_one_to_many_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -105,13 +109,13 @@ def test_many_to_one_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -134,9 +138,10 @@ async def test_one_to_many_with_traffic_model(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -158,9 +163,10 @@ async def test_many_to_one_with_traffic_model(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],
@@ -181,9 +187,10 @@ def test_one_to_many_with_traffic_model_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -204,9 +211,10 @@ def test_many_to_one_with_traffic_model_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],
@@ -228,13 +236,13 @@ async def test_union_one_to_many(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -257,13 +265,13 @@ async def test_intersection_many_to_one(async_client: AsyncClient):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -287,13 +295,13 @@ def test_union_one_to_many_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -315,13 +323,13 @@ def test_intersection_many_to_one_sync(client: Client):
                 H3FastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 H3FastSearch(
                     id="id 2",
                     coords=H3Centroid(h3_centroid="87195da49ffffff"),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],

--- a/tests/time_filter_fast_test.py
+++ b/tests/time_filter_fast_test.py
@@ -7,9 +7,12 @@ from traveltimepy.requests.time_filter_fast import (
     TimeFilterFastArrivalSearches,
     TimeFilterFastOneToMany,
     TimeFilterFastManyToOne,
+)
+from traveltimepy.requests.transportation import (
+    DrivingFerryFast,
+    PublicTransportFast,
     FastTrafficModel,
 )
-from traveltimepy.requests.transportation import TransportationFast
 
 
 @pytest.mark.asyncio
@@ -22,7 +25,7 @@ async def test_one_to_many(async_client: AsyncClient, locations):
                     id="London center",
                     departure_location_id="London center",
                     arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -30,7 +33,7 @@ async def test_one_to_many(async_client: AsyncClient, locations):
                     id="ZSL London Zoo",
                     departure_location_id="ZSL London Zoo",
                     arrival_location_ids=["Hyde Park", "London center"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -52,7 +55,7 @@ async def test_many_to_one(async_client: AsyncClient, locations):
                     id="London center",
                     arrival_location_id="London center",
                     departure_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -60,7 +63,7 @@ async def test_many_to_one(async_client: AsyncClient, locations):
                     id="ZSL London Zoo",
                     arrival_location_id="ZSL London Zoo",
                     departure_location_ids=["Hyde Park", "London center"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -81,7 +84,7 @@ def test_one_to_many_sync(client: Client, locations):
                     id="London center",
                     departure_location_id="London center",
                     arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -89,7 +92,7 @@ def test_one_to_many_sync(client: Client, locations):
                     id="ZSL London Zoo",
                     departure_location_id="ZSL London Zoo",
                     arrival_location_ids=["Hyde Park", "London center"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -110,7 +113,7 @@ def test_many_to_one_sync(client: Client, locations):
                     id="London center",
                     arrival_location_id="London center",
                     departure_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -118,7 +121,7 @@ def test_many_to_one_sync(client: Client, locations):
                     id="ZSL London Zoo",
                     arrival_location_id="ZSL London Zoo",
                     departure_location_ids=["Hyde Park", "London center"],
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
                 ),
@@ -140,10 +143,11 @@ async def test_one_to_many_with_traffic_model(async_client: AsyncClient, locatio
                     id="London center",
                     departure_location_id="London center",
                     arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -163,10 +167,11 @@ async def test_many_to_one_with_traffic_model(async_client: AsyncClient, locatio
                     id="London center",
                     arrival_location_id="London center",
                     departure_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],
@@ -185,10 +190,11 @@ def test_one_to_many_with_traffic_model_sync(client: Client, locations):
                     id="London center",
                     departure_location_id="London center",
                     arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -207,10 +213,11 @@ def test_many_to_one_with_traffic_model_sync(client: Client, locations):
                     id="London center",
                     arrival_location_id="London center",
                     departure_location_ids=["Hyde Park", "ZSL London Zoo"],
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=1800,
                     properties=[Property.TRAVEL_TIME],
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],

--- a/tests/time_map_fast_test.py
+++ b/tests/time_map_fast_test.py
@@ -7,7 +7,11 @@ from traveltimepy.requests.time_map_fast import (
     TimeMapFastArrivalSearches,
     TimeMapFastSearch,
 )
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    DrivingFerryFast,
+    FastTrafficModel,
+    PublicTransportFast,
+)
 
 
 @pytest.mark.asyncio
@@ -18,13 +22,13 @@ async def test_one_to_many(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -43,13 +47,13 @@ async def test_many_to_one(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -68,13 +72,13 @@ async def test_one_to_many_geojson(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -93,13 +97,13 @@ async def test_many_to_one_geojson(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -118,13 +122,13 @@ async def test_one_to_many_wkt(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -143,13 +147,13 @@ async def test_many_to_one_wkt(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -168,13 +172,13 @@ async def test_one_to_many_wkt_no_holes(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -193,13 +197,13 @@ async def test_many_to_one_wkt_no_holes(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -217,13 +221,13 @@ def test_one_to_many_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -241,13 +245,13 @@ def test_many_to_one_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -265,13 +269,13 @@ def test_one_to_many_geojson_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -289,13 +293,13 @@ def test_many_to_one_geojson_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -313,13 +317,13 @@ def test_one_to_many_wkt_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -337,13 +341,13 @@ def test_many_to_one_wkt_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -361,13 +365,13 @@ def test_one_to_many_wkt_no_holes_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -385,13 +389,13 @@ def test_many_to_one_wkt_no_holes_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
                 TimeMapFastSearch(
                     id="id 2",
                     coords=Coordinates(lat=51.517609, lng=-0.138315),
-                    transportation=TransportationFast.PUBLIC_TRANSPORT,
+                    transportation=PublicTransportFast(),
                     travel_time=900,
                 ),
             ],
@@ -410,9 +414,10 @@ async def test_one_to_many_with_traffic_model(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -430,9 +435,10 @@ async def test_many_to_one_with_traffic_model(async_client: AsyncClient):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],
@@ -449,9 +455,10 @@ def test_one_to_many_with_traffic_model_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.PEAK,
                 ),
             ],
             many_to_one=[],
@@ -468,9 +475,10 @@ def test_many_to_one_with_traffic_model_sync(client: Client):
                 TimeMapFastSearch(
                     id="id",
                     coords=Coordinates(lat=51.507609, lng=-0.128315),
-                    transportation=TransportationFast.DRIVING_FERRY,
+                    transportation=DrivingFerryFast(
+                        traffic_model=FastTrafficModel.OFF_PEAK
+                    ),
                     travel_time=900,
-                    traffic_model=FastTrafficModel.OFF_PEAK,
                 ),
             ],
             one_to_many=[],

--- a/traveltimepy/requests/geohash_fast.py
+++ b/traveltimepy/requests/geohash_fast.py
@@ -1,9 +1,17 @@
-from typing import List, Optional
-import typing
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    PublicTransportFast,
+    DrivingFast,
+    CyclingFast,
+    WalkingFast,
+    WalkingFerryFast,
+    CyclingFerryFast,
+    DrivingFerryFast,
+    DrivingPublicTransportFast,
+)
 from traveltimepy.requests.common import (
     CellProperty,
     Coordinates,
@@ -26,24 +34,27 @@ class GeoHashFastSearch(BaseModel):
     Attributes:
         id: Unique identifier for this search operation.
         coords: Location coordinates using either lat/lng or geohash centroid.
-        transportation: Transportation mode for the journey calculation (limited options for performance).
+        transportation: Transportation mode.
         travel_time: Maximum journey time in seconds. Maximum value is 10800 (3 hours).
         arrival_time_period: Time period for the search instead of specific time.
         snapping: Configuration for connecting coordinates to the transportation network.
-        traffic_model: Traffic model for driving journeys (peak/off_peak).
     """
 
     id: str
-    coords: typing.Union[Coordinates, GeohashCentroid]
-    transportation: TransportationFast
+    coords: Union[Coordinates, GeohashCentroid]
+    transportation: Union[
+        PublicTransportFast,
+        DrivingFast,
+        CyclingFast,
+        WalkingFast,
+        WalkingFerryFast,
+        CyclingFerryFast,
+        DrivingFerryFast,
+        DrivingPublicTransportFast,
+    ]
     travel_time: int
     arrival_time_period: ArrivalTimePeriod = ArrivalTimePeriod.WEEKDAY_MORNING
     snapping: Optional[Snapping] = None
-    traffic_model: FastTrafficModel = FastTrafficModel.PEAK
-
-    @field_serializer("transportation")
-    def serialize_transportation(self, value: TransportationFast) -> dict:
-        return {"type": value.value}
 
 
 class GeoHashFastArrivalSearches(BaseModel):

--- a/traveltimepy/requests/h3_fast.py
+++ b/traveltimepy/requests/h3_fast.py
@@ -1,7 +1,6 @@
-from typing import List, Optional
-import typing
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
 from traveltimepy.requests.common import (
     CellProperty,
@@ -13,7 +12,16 @@ from traveltimepy.requests.common import (
 from traveltimepy.requests.request import TravelTimeRequest
 from traveltimepy.responses.h3 import H3Response
 from traveltimepy.itertools import split, flatten
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    PublicTransportFast,
+    DrivingFast,
+    CyclingFast,
+    WalkingFast,
+    WalkingFerryFast,
+    CyclingFerryFast,
+    DrivingFerryFast,
+    DrivingPublicTransportFast,
+)
 
 
 class H3FastSearch(BaseModel):
@@ -22,28 +30,30 @@ class H3FastSearch(BaseModel):
     Attributes:
         id: Unique identifier for this search - must be unique across all searches in a request
         coords: Starting/ending coordinates - can be lat/lng coordinates or H3 cell centroid
-        transportation: Transportation method (public_transport, walking+ferry, cycling+ferry, etc.)
+        transportation: Transportation method.
         travel_time: Maximum journey time in seconds (max 10800s).
                          Maximum value depends on resolution parameter.
                          Limitations can be found here:
                          https://docs.traveltime.com/api/reference/h3-fast#limits-of-resolution-and-traveltime.
         arrival_time_period: Time period for the search
         snapping: Optional settings for adjusting road network lookup behavior
-        traffic_model: Traffic model for driving journeys (peak/off_peak)
     """
 
     id: str
-    coords: typing.Union[Coordinates, H3Centroid]
-    transportation: TransportationFast
+    coords: Union[Coordinates, H3Centroid]
+    transportation: Union[
+        PublicTransportFast,
+        DrivingFast,
+        CyclingFast,
+        WalkingFast,
+        WalkingFerryFast,
+        CyclingFerryFast,
+        DrivingFerryFast,
+        DrivingPublicTransportFast,
+    ]
     travel_time: int
     arrival_time_period: ArrivalTimePeriod = ArrivalTimePeriod.WEEKDAY_MORNING
     snapping: Optional[Snapping] = None
-    traffic_model: FastTrafficModel = FastTrafficModel.PEAK
-
-    # JSON expects `"transportation": { "type": "public_transport" }` and not `"transportation": "public_transport"`
-    @field_serializer("transportation")
-    def serialize_transportation(self, value: TransportationFast) -> dict:
-        return {"type": value.value}
 
 
 class H3FastArrivalSearches(BaseModel):

--- a/traveltimepy/requests/time_filter_fast.py
+++ b/traveltimepy/requests/time_filter_fast.py
@@ -1,8 +1,17 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    PublicTransportFast,
+    DrivingFast,
+    CyclingFast,
+    WalkingFast,
+    WalkingFerryFast,
+    CyclingFerryFast,
+    DrivingFerryFast,
+    DrivingPublicTransportFast,
+)
 from traveltimepy.requests.common import Location, Property, Snapping, ArrivalTimePeriod
 from traveltimepy.requests.request import TravelTimeRequest
 from traveltimepy.responses.time_filter_fast import TimeFilterFastResponse
@@ -24,23 +33,25 @@ class TimeFilterFastOneToMany(BaseModel):
         properties: Data to return (travel_time, distance, fares)
         arrival_time_period: Time period instead of specific time
         snapping: Optional road network lookup settings
-        traffic_model: Traffic model for driving journeys (peak/off_peak)
     """
 
     id: str
     departure_location_id: str
     arrival_location_ids: List[str]
-    transportation: TransportationFast
+    transportation: Union[
+        PublicTransportFast,
+        DrivingFast,
+        CyclingFast,
+        WalkingFast,
+        WalkingFerryFast,
+        CyclingFerryFast,
+        DrivingFerryFast,
+        DrivingPublicTransportFast,
+    ]
     travel_time: int
     properties: List[Property]
     arrival_time_period: ArrivalTimePeriod = ArrivalTimePeriod.WEEKDAY_MORNING
     snapping: Optional[Snapping] = None
-    traffic_model: FastTrafficModel = FastTrafficModel.PEAK
-
-    # JSON expects `"transportation": { "type": "public_transport" }` and not `"transportation": "public_transport"`
-    @field_serializer("transportation")
-    def serialize_transportation(self, value: TransportationFast) -> dict:
-        return {"type": value.value}
 
 
 class TimeFilterFastManyToOne(BaseModel):
@@ -58,23 +69,25 @@ class TimeFilterFastManyToOne(BaseModel):
         properties: Data to return (travel_time, distance, fares)
         arrival_time_period: Time period instead of specific time
         snapping: Optional road network lookup settings
-        traffic_model: Traffic model for driving journeys (peak/off_peak)
     """
 
     id: str
     arrival_location_id: str
     departure_location_ids: List[str]
-    transportation: TransportationFast
+    transportation: Union[
+        PublicTransportFast,
+        DrivingFast,
+        CyclingFast,
+        WalkingFast,
+        WalkingFerryFast,
+        CyclingFerryFast,
+        DrivingFerryFast,
+        DrivingPublicTransportFast,
+    ]
     travel_time: int
     properties: List[Property]
     arrival_time_period: ArrivalTimePeriod = ArrivalTimePeriod.WEEKDAY_MORNING
     snapping: Optional[Snapping] = None
-    traffic_model: FastTrafficModel = FastTrafficModel.PEAK
-
-    # JSON expects `"transportation": { "type": "public_transport" }` and not `"transportation": "public_transport"`
-    @field_serializer("transportation")
-    def serialize_transportation(self, value: TransportationFast) -> dict:
-        return {"type": value.value}
 
 
 class TimeFilterFastArrivalSearches(BaseModel):

--- a/traveltimepy/requests/time_map_fast.py
+++ b/traveltimepy/requests/time_map_fast.py
@@ -1,6 +1,6 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
 from traveltimepy.requests.common import (
     Coordinates,
@@ -13,7 +13,16 @@ from traveltimepy.requests.level_of_detail import LevelOfDetail
 from traveltimepy.requests.request import TravelTimeRequest
 from traveltimepy.responses.time_map import TimeMapResponse
 from traveltimepy.itertools import split, flatten
-from traveltimepy.requests.transportation import TransportationFast, FastTrafficModel
+from traveltimepy.requests.transportation import (
+    PublicTransportFast,
+    DrivingFast,
+    CyclingFast,
+    WalkingFast,
+    WalkingFerryFast,
+    CyclingFerryFast,
+    DrivingFerryFast,
+    DrivingPublicTransportFast,
+)
 
 
 class TimeMapFastSearch(BaseModel):
@@ -30,7 +39,6 @@ class TimeMapFastSearch(BaseModel):
         snapping: Optional road network lookup settings
         polygons_filter: Optional filtering for polygon complexity
         render_mode: Optional rendering mode for polygon output
-        traffic_model: Traffic model for driving journeys (peak/off_peak)
         buffer_distance: Optional integer. minimum value is 250 meters. Default value is 1000 meters.
                 - When `render_mode=approximate_time_filter` - controls how far from the reached road
                   network the isochrone generation algorithm may consider locations as reachable.
@@ -41,7 +49,16 @@ class TimeMapFastSearch(BaseModel):
 
     id: str
     coords: Coordinates
-    transportation: TransportationFast
+    transportation: Union[
+        PublicTransportFast,
+        DrivingFast,
+        CyclingFast,
+        WalkingFast,
+        WalkingFerryFast,
+        CyclingFerryFast,
+        DrivingFerryFast,
+        DrivingPublicTransportFast,
+    ]
     travel_time: int
     arrival_time_period: ArrivalTimePeriod = ArrivalTimePeriod.WEEKDAY_MORNING
     level_of_detail: Optional[LevelOfDetail] = None
@@ -49,12 +66,6 @@ class TimeMapFastSearch(BaseModel):
     polygons_filter: Optional[PolygonsFilter] = None
     render_mode: Optional[RenderMode] = None
     buffer_distance: Optional[int] = None
-    traffic_model: FastTrafficModel = FastTrafficModel.PEAK
-
-    # JSON expects `"transportation": { "type": "public_transport" }` and not `"transportation": "public_transport"`
-    @field_serializer("transportation")
-    def serialize_transportation(self, value: TransportationFast) -> dict:
-        return {"type": value.value}
 
 
 class TimeMapFastArrivalSearches(BaseModel):

--- a/traveltimepy/requests/transportation.py
+++ b/traveltimepy/requests/transportation.py
@@ -68,7 +68,7 @@ class CyclingPublicTransport(BaseModel):
     max_changes: Optional[MaxChanges] = None
 
 
-class TransportationFast(str, Enum):
+class TransportationFastType(str, Enum):
     PUBLIC_TRANSPORT = "public_transport"
     DRIVING = "driving"
     CYCLING = "cycling"
@@ -89,3 +89,37 @@ class FastTrafficModel(str, Enum):
 
     PEAK = "peak"
     OFF_PEAK = "off_peak"
+
+
+class PublicTransportFast(BaseModel):
+    type: Literal["public_transport"] = "public_transport"
+
+
+class WalkingFast(BaseModel):
+    type: Literal["walking"] = "walking"
+
+
+class CyclingFast(BaseModel):
+    type: Literal["cycling"] = "cycling"
+
+
+class DrivingFast(BaseModel):
+    type: Literal["driving"] = "driving"
+    traffic_model: Optional[FastTrafficModel] = None
+
+
+class WalkingFerryFast(BaseModel):
+    type: Literal["walking+ferry"] = "walking+ferry"
+
+
+class CyclingFerryFast(BaseModel):
+    type: Literal["cycling+ferry"] = "cycling+ferry"
+
+
+class DrivingFerryFast(BaseModel):
+    type: Literal["driving+ferry"] = "driving+ferry"
+    traffic_model: Optional[FastTrafficModel] = None
+
+
+class DrivingPublicTransportFast(BaseModel):
+    type: Literal["driving+public_transport"] = "driving+public_transport"


### PR DESCRIPTION
Current implementation of `traffic_model` is not actually working, because it should be nested inside the `transportation` object. This PR is attempting to fix that.

It makes 2 breaking changes, illustrated here https://github.com/traveltime-dev/traveltime-python-sdk/pull/193#discussion_r2794407751, with the goal of making fast endpoints more similar to the regular ones (and more extensible)

My question for the reviewers - do you think it's worth keeping backwards compatibility for:
1. The old way of setting transportation mode on fast endpoints using the enum
2. The old way of setting traffic_model (I can even make it actually work with custom json encoding)

If we do keep backwards compatibility for both, there can be weird scenarios where the user specifies traffic model in both the OLD and NEW ways, so at most I'd support `#1` but not `#2`. Ideally neither