### PR TITLE
Add include_roads and snapping threshold parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
 	"pytest-asyncio",
 	"flake8",
 	"flake8-pyproject",
-	"mypy",
+	"mypy<2",
 	"black",
 	"types-shapely",
 	"docformatter",

--- a/tests/time_filter_fast_test.py
+++ b/tests/time_filter_fast_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from traveltimepy import AsyncClient
 from traveltimepy.client import Client
-from traveltimepy.requests.common import Property
+from traveltimepy.requests.common import Property, Snapping
 from traveltimepy.requests.time_filter_fast import (
     TimeFilterFastArrivalSearches,
     TimeFilterFastOneToMany,
@@ -221,6 +221,53 @@ def test_many_to_one_with_traffic_model_sync(client: Client, locations):
                 ),
             ],
             one_to_many=[],
+        ),
+    )
+
+    assert len(response.results) > 0
+
+
+@pytest.mark.asyncio
+async def test_many_to_one_with_snapping_threshold(
+    async_client: AsyncClient, locations
+):
+    response = await async_client.time_filter_fast(
+        locations=locations,
+        arrival_searches=TimeFilterFastArrivalSearches(
+            many_to_one=[
+                TimeFilterFastManyToOne(
+                    id="London center",
+                    arrival_location_id="London center",
+                    departure_location_ids=["Hyde Park", "ZSL London Zoo"],
+                    transportation=PublicTransportFast(),
+                    travel_time=1800,
+                    properties=[Property.TRAVEL_TIME],
+                    snapping=Snapping(threshold=500),
+                ),
+            ],
+            one_to_many=[],
+        ),
+    )
+
+    assert len(response.results) > 0
+
+
+def test_one_to_many_with_snapping_threshold_sync(client: Client, locations):
+    response = client.time_filter_fast(
+        locations=locations,
+        arrival_searches=TimeFilterFastArrivalSearches(
+            one_to_many=[
+                TimeFilterFastOneToMany(
+                    id="London center",
+                    departure_location_id="London center",
+                    arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
+                    transportation=PublicTransportFast(),
+                    travel_time=1800,
+                    properties=[Property.TRAVEL_TIME],
+                    snapping=Snapping(threshold=500),
+                ),
+            ],
+            many_to_one=[],
         ),
     )
 

--- a/tests/time_filter_test.py
+++ b/tests/time_filter_test.py
@@ -9,7 +9,11 @@ from traveltimepy.requests.time_filter import (
     TimeFilterDepartureSearch,
     TimeFilterArrivalSearch,
 )
-from traveltimepy.requests.transportation import PublicTransport
+from traveltimepy.requests.transportation import (
+    Driving,
+    IncludeRoads,
+    PublicTransport,
+)
 
 
 @pytest.mark.asyncio
@@ -124,3 +128,46 @@ def test_arrivals_sync(client: Client, locations):
         departure_searches=[],
     )
     assert len(response.results) == 2
+
+
+@pytest.mark.asyncio
+async def test_departures_with_include_roads(async_client: AsyncClient, locations):
+    response = await async_client.time_filter(
+        locations=locations,
+        departure_searches=[
+            TimeFilterDepartureSearch(
+                id="London center",
+                departure_location_id="London center",
+                arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
+                departure_time=datetime.now(),
+                transportation=Driving(
+                    include_roads=[IncludeRoads.TRACK, IncludeRoads.RESTRICTED]
+                ),
+                travel_time=1800,
+                properties=[Property.TRAVEL_TIME],
+            ),
+        ],
+        arrival_searches=[],
+    )
+    assert len(response.results) == 1
+
+
+def test_departures_with_include_roads_sync(client: Client, locations):
+    response = client.time_filter(
+        locations=locations,
+        departure_searches=[
+            TimeFilterDepartureSearch(
+                id="London center",
+                departure_location_id="London center",
+                arrival_location_ids=["Hyde Park", "ZSL London Zoo"],
+                departure_time=datetime.now(),
+                transportation=Driving(
+                    include_roads=[IncludeRoads.TRACK, IncludeRoads.RESTRICTED]
+                ),
+                travel_time=1800,
+                properties=[Property.TRAVEL_TIME],
+            ),
+        ],
+        arrival_searches=[],
+    )
+    assert len(response.results) == 1

--- a/traveltimepy/requests/common.py
+++ b/traveltimepy/requests/common.py
@@ -248,7 +248,7 @@ class Snapping(BaseModel):
                      Determines whether journeys can snap to vehicle-only roads or only pedestrian-accessible roads.
         threshold: Maximum distance in meters between locations and the nearest accessible road.
                   Defaults to 1000 meters. Departure locations exceeding this return errors,
-                  arrival locations return unreachable results. Not supported by H3 and geohash endpoints.
+                  arrival locations return unreachable results.
     """
 
     penalty: Optional[SnappingPenalty] = SnappingPenalty.ENABLED

--- a/traveltimepy/requests/common.py
+++ b/traveltimepy/requests/common.py
@@ -246,12 +246,16 @@ class Snapping(BaseModel):
                 When enabled, includes "first and last mile" walking times/distances for realistic door-to-door calculations.
         accept_roads: Defines which road types are valid as journey start/end points.
                      Determines whether journeys can snap to vehicle-only roads or only pedestrian-accessible roads.
+        threshold: Maximum distance in meters between locations and the nearest accessible road.
+                  Defaults to 1000 meters. Departure locations exceeding this return errors,
+                  arrival locations return unreachable results. Not supported by H3 and geohash endpoints.
     """
 
     penalty: Optional[SnappingPenalty] = SnappingPenalty.ENABLED
     accept_roads: Optional[SnappingAcceptRoads] = (
         SnappingAcceptRoads.BOTH_DRIVABLE_AND_WALKABLE
     )
+    threshold: Optional[int] = None
 
 
 class ProtoProperty(int, Enum):

--- a/traveltimepy/requests/transportation.py
+++ b/traveltimepy/requests/transportation.py
@@ -14,8 +14,9 @@ class MaxChanges(BaseModel):
 
 
 class IncludeRoads(str, Enum):
-    """Additional road types to include when executing a search. By default all of
-    these roads are excluded.
+    """Additional road types to include when executing a search.
+
+    By default all of these roads are excluded.
 
     Attributes:
         TRACK: Unpaved roads that only allow very slow driving speed or may require

--- a/traveltimepy/requests/transportation.py
+++ b/traveltimepy/requests/transportation.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 from typing_extensions import Literal
 
 from pydantic.main import BaseModel
@@ -13,10 +13,25 @@ class MaxChanges(BaseModel):
     limit: int
 
 
+class IncludeRoads(str, Enum):
+    """Additional road types to include when executing a search. By default all of
+    these roads are excluded.
+
+    Attributes:
+        TRACK: Unpaved roads that only allow very slow driving speed or may require
+               an off-road capable vehicle.
+        RESTRICTED: Roads that are not publicly accessible and may require a special permit.
+    """
+
+    TRACK = "track"
+    RESTRICTED = "restricted"
+
+
 class Driving(BaseModel):
     type: Literal["driving"] = "driving"
     disable_border_crossing: Optional[bool] = None
     traffic_model: Optional[DrivingTrafficModel] = None
+    include_roads: Optional[List[IncludeRoads]] = None
 
 
 class Walking(BaseModel):
@@ -31,12 +46,21 @@ class Ferry(BaseModel):
     type: Literal["ferry", "cycling+ferry", "driving+ferry"] = "ferry"
     boarding_time: Optional[int] = None
     traffic_model: Optional[DrivingTrafficModel] = None
+    include_roads: Optional[List[IncludeRoads]] = None
 
     @model_validator(mode="after")
     def check_traffic_model(self):
         if self.type != "driving+ferry" and self.traffic_model:
             raise ValueError(
                 '"traffic_model" cannot be specified when type is not "driving+ferry"'
+            )
+        return self
+
+    @model_validator(mode="after")
+    def check_include_roads(self):
+        if self.type != "driving+ferry" and self.include_roads:
+            raise ValueError(
+                '"include_roads" cannot be specified when type is not "driving+ferry"'
             )
         return self
 


### PR DESCRIPTION
Closes #192, closes #189.

- `include_roads` on `Driving` and `Ferry` (validated to `driving+ferry` only, same pattern as `traffic_model`)
- `threshold` on `Snapping` (max snap distance in meters, API default 1000)
- Pinned mypy to `<2` — mypy 2.x (released after the last CI run on master) flags pre-existing code in `traveltimepy/itertools.py`; will be fixed separately

Both parameters verified against the live API, integration tests added.